### PR TITLE
fix letter case inconsistency between filesystem paths and templates.…

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "polkadot-starter",
+    "name": "Polkadot-starter",
     "description": "Starter project for subquery",
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
@@ -21,11 +21,10 @@
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
     "network": "Astar",
-
     "family": "Substrate"
   },
   {
-    "name": "moonbeam-starter",
+    "name": "Moonbeam-starter",
     "description": "Starter project for Moonbeam",
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
@@ -38,7 +37,6 @@
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
     "network": "Statemine",
-
     "family": "Substrate"
   },
   {
@@ -47,7 +45,6 @@
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
     "network": "Statemint",
-
     "family": "Substrate"
   },
   {
@@ -56,7 +53,6 @@
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
     "network": "Parallel",
-
     "family": "Substrate"
   },
   {
@@ -73,7 +69,6 @@
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
     "network": "Clover",
-
     "family": "Substrate"
   },
   {
@@ -82,7 +77,6 @@
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
     "network": "Astar",
-
     "family": "Substrate"
   },
   {
@@ -91,7 +85,6 @@
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
     "network": "Acala",
-
     "family": "Substrate"
   },
   {
@@ -100,7 +93,6 @@
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
     "network": "Altair",
-
     "family": "Substrate"
   },
   {
@@ -109,7 +101,6 @@
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
     "network": "Automata",
-
     "family": "Substrate"
   },
   {
@@ -118,7 +109,6 @@
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
     "network": "Basilisk",
-
     "family": "Substrate"
   },
   {
@@ -127,7 +117,6 @@
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
     "network": "Bifrost",
-
     "family": "Substrate"
   },
   {
@@ -136,7 +125,6 @@
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
     "network": "Bit.Country",
-
     "family": "Substrate"
   },
   {
@@ -152,7 +140,7 @@
     "description": "Starter project for Contextfree",
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
-    "network": "ContextFree",
+    "network": "Contextfree",
     "family": "Substrate"
   },
   {
@@ -185,7 +173,6 @@
     "remote": "https://github.com/subquery/subql-starter",
     "branch": "main",
     "network": "Parallel",
-
     "family": "Substrate"
   },
   {


### PR DESCRIPTION
Hi, I just start learning SubQuery and run into some mistakes when running `subql init`. It turns out that there are some typos in templates.json that make git synchronization fails in these 2 lines https://github.com/subquery/subql/blob/main/packages/cli/src/controller/init-controller.ts#L68-L69, the reason is that some of the file paths composed from templates.json do not reflect the actual paths in OS, for example, if we run this 2 commands

```shell
git sparse-checkout set Polkadot/polkadot-starter
git pull origin main
```

nothing will actually be pulled because the right "sparse-checkout" should be "Polkadot/Polkadot-starter", the second letter P is capital, but in templates.json, the second P is lowercase: https://github.com/subquery/templates/blob/multi/templates.json#L3

The same thing happens to https://github.com/subquery/subql-starter/tree/main/Moonbeam/Moonbeam-starter

So I just wrote a script to fix them all : https://gist.githubusercontent.com/tenheadedlion/f12f95761275b5cf7ddfbf1b7b77c893/raw/2fb1e51d65560a9d46ea49df32bed35ec77d8e78/gistfile1.txt










