### PR TITLE
update moonbeam/moonriver dictionary

### DIFF
--- a/dist/dictionary.json
+++ b/dist/dictionary.json
@@ -102,12 +102,6 @@
     "calamari": [
       "https://api.subquery.network/sq/subquery/calamari-dictionary"
     ],
-    "moonbeam": [
-      "https://dict-tyk.subquery.network/query/moonbeam"
-    ],
-    "moonriver": [
-      "https://dict-tyk.subquery.network/query/moonriver"
-    ],
     "parallel": [
       "https://api.subquery.network/sq/subquery/parallel-dictionary"
     ],

--- a/dist/output.json
+++ b/dist/output.json
@@ -2193,9 +2193,7 @@
             "link": "https://academy.subquery.network/quickstart/quickstart_chains/polkadot-moonbeam.html"
           }
         ],
-        "dictionaries": [
-          "https://dict-tyk.subquery.network/query/moonbeam"
-        ]
+        "dictionaries": []
       },
       {
         "code": "moonriver",
@@ -2218,9 +2216,7 @@
           }
         ],
         "guides": [],
-        "dictionaries": [
-          "https://dict-tyk.subquery.network/query/moonriver"
-        ]
+        "dictionaries": []
       },
       {
         "code": "nodle",

--- a/index.ts
+++ b/index.ts
@@ -2449,7 +2449,7 @@ const networkFamilies: NetworkFamily[] = [
             link: "https://academy.subquery.network/quickstart/quickstart_chains/polkadot-moonbeam.html",
           },
         ],
-        dictionaries: ["https://dict-tyk.subquery.network/query/moonbeam"],
+        dictionaries: [],
       },
       {
         code: "moonriver",
@@ -2474,7 +2474,7 @@ const networkFamilies: NetworkFamily[] = [
           },
         ],
         guides: [],
-        dictionaries: ["https://dict-tyk.subquery.network/query/moonriver"],
+        dictionaries: [],
       },
       {
         code: "nodle",


### PR DESCRIPTION
tky dict are only for evm chains.
Moonbeam and moonriver needs substrate dictionary, unless people use subql-ethereum, in that case, we should put a different entry under evm for them.