### PR TITLE
Fixed typos in Polkadot network templates

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2326,10 +2326,10 @@ const networkFamilies: NetworkFamily[] = [
         logo: "https://static.subquery.network/network-logos/encointer.png",
         examples: [
           {
-            name: "encointer-starter",
+            name: "Encointer-starter",
             description: "",
             remote: "https://github.com/subquery/subql-starter",
-            path: "Encointer/encointer-starter",
+            path: "Encointer/Encointer-starter",
           },
         ],
         guides: [],
@@ -2380,7 +2380,7 @@ const networkFamilies: NetworkFamily[] = [
             name: "hashed-network-starter",
             description: "",
             remote: "https://github.com/subquery/subql-starter",
-            path: "Hashed Network/hashed-network-starter",
+            path: "HashedNetwork/hashed-network-starter",
           },
         ],
         guides: [],
@@ -2394,10 +2394,10 @@ const networkFamilies: NetworkFamily[] = [
         logo: "https://static.subquery.network/network-logos/humanode.png",
         examples: [
           {
-            name: "humanode-starter",
+            name: "Humanode-starter",
             description: "",
             remote: "https://github.com/subquery/subql-starter",
-            path: "Humanode/humanode-starter",
+            path: "Humanode/Humanode-starter",
           },
         ],
         guides: [
@@ -2439,7 +2439,7 @@ const networkFamilies: NetworkFamily[] = [
             name: "integritee-shell-starter",
             description: "",
             remote: "https://github.com/subquery/subql-starter",
-            path: "Integritee Shell/integritee-shell-starter",
+            path: "IntegriteeShell/integritee-shell-starter",
           },
         ],
         guides: [],
@@ -2715,10 +2715,10 @@ const networkFamilies: NetworkFamily[] = [
         logo: "https://static.subquery.network/network-logos/polkadex-standalone.png",
         examples: [
           {
-            name: "polkedex-starter",
+            name: "polkadex-starter",
             description: "",
             remote: "https://github.com/subquery/subql-starter",
-            path: "Polkadex/polkedex-starter",
+            path: "Polkadex/polkadex-starter",
           },
         ],
         guides: [],
@@ -2757,10 +2757,10 @@ const networkFamilies: NetworkFamily[] = [
         logo: "https://static.subquery.network/network-logos/quartz.png",
         examples: [
           {
-            name: "quartz-starter",
+            name: "quartz-subql-starter",
             description: "",
             remote: "https://github.com/subquery/subql-starter",
-            path: "Quartz/quartz-starter",
+            path: "Quartz/quartz-subql-starter",
           },
         ],
         guides: [],


### PR DESCRIPTION
Some of the templates in the Polkadot network have typos when compared to the [subql-starter](https://github.com/subquery/subql-starter) repo. This is causing the `subql init` flow to break when trying to use those templates as seen in the below screenshots.

![Polkadex subql init](https://github.com/subquery/templates/assets/37153833/00d7850f-f0e5-4c83-b7b1-52e65f18cd49)

![Hashed network subql init](https://github.com/subquery/templates/assets/37153833/d40230ff-9d08-4956-a9f4-1953d8188c54)

![Quartz subql init](https://github.com/subquery/templates/assets/37153833/40ca3fc7-6fbf-471a-af07-05cc69fc33d6)

This PR corrects those typos.